### PR TITLE
Fix JasminResult.run() not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone --single-branch ${JMM_BRANCH:+--branch $JMM_BRANCH} ${JMM_URL} com
 
 RUN cd compiler_git && gradle installDist
 
-RUN mkdir -p compiler && cp -r compiler_git/config.properties compiler_git/build/install/jmm compiler/
+RUN mkdir -p compiler && cp -r compiler_git/config.properties compiler_git/libs-jmm compiler_git/build/install/jmm compiler/
 
 FROM ${JMM_STRATEGY} AS strategy
 
@@ -62,7 +62,7 @@ RUN \
 # Production image, copy all the files and run next
 FROM base AS runner
 
-RUN apk add --no-cache openjdk21-jre
+RUN apk add --no-cache openjdk21-jre bash
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.


### PR DESCRIPTION
`JasminResult.run()` had two problems in my compiler deployment, namely: the `libs-jmm` directory was required to be able to interact with the outside world, and `bash` was also required to run the program, which wasn't available in the alpine based image